### PR TITLE
Add mosh server with unstable conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,40 +31,41 @@ When you want to add new server configuration follow step below:
 
 ## Table of available hosts
 
-|               Service                | Port |    User     |  Password   |                      Key                      |
-|:------------------------------------:|:----:|:-----------:|:-----------:|:---------------------------------------------:|
-|                 pass                 | 2201 |     sa      |    pass     |                       -                       |
-|                 key                  | 2202 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|               authykey               | 2203 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              authypass               | 2204 | Authy users | authy_token |                       -                       |
-|                 otp                  | 2205 |     sa      |      -      |             [keys](/otp/keys.txt)             |
-|               ed25519                | 2206 |     sa      |      -      |        [ed25519 key](/keys/id_ed25519)        |
-|            ecdsa-nistp256            | 2207 |     sa      |      -      |   [ecDSA 256 key](/keys/id_ecdsa_nistp256)    |
-|            ecdsa-nistp384            | 2218 |     sa      |      -      |   [ecDSA 384 key](/keys/id_ecdsa_nistp384)    |
-|            ecdsa-nistp521            | 2219 |     sa      |      -      |   [ecDSA 521 key](/keys/id_ecdsa_nistp521)    |
-|            hmac-sha2-256             | 2208 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|            hmac-sha2-512             | 2209 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|   chacha20-poly1305_at_openssh.com   | 2210 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              aes128-ctr              | 2211 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              aes192-ctr              | 2212 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              aes256-ctr              | 2213 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|          curve25519-sha256           | 2214 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-| diffie-hellman-group-exchange-sha256 | 2215 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|                telnet                | 2216 |     sa      |    pass     |                       -                       |
-|                chain1                | 2217 |   chain1    |      1      |                       -                       |
-|                chain2                |  -   |   chain2    |      -      |            [rsa key](/keys/id_rsa)            |
-|                chain3                |  -   |   chain3    |      -      |           [rsa1 key](/keys/id_rsa1)           |
-|               yuubikey               | 2220 |     sa      |      -      |                       -                       |
-|             yuubikey-pam             | 2221 |     sa      |      -      |                       -                       |
-|      agent-forwarding-disabled       | 2222 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|            gateway-ports             | 2223 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|                 mosh                 | 2224 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|            multiple-auths            | 2225 |     sa      |    pass     |            [rsa key](/keys/id_rsa)            |
-|      keyboard-interactive-pass       | 2226 |     sa      |    pass     |                       -                       |
-|            sftp-disabled             | 2227 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|             pf-disabled              | 2228 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|             pf-case-jump             | 2230 |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|             client-cert              | 2231 |     sa      |      -      | [user certificate key](/client-cert/user-key) |
+|               Service                |       Port        |    User     |  Password   |                      Key                      |
+|:------------------------------------:|:-----------------:|:-----------:|:-----------:|:---------------------------------------------:|
+|                 pass                 |       2201        |     sa      |    pass     |                       -                       |
+|                 key                  |       2202        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|               authykey               |       2203        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              authypass               |       2204        | Authy users | authy_token |                       -                       |
+|                 otp                  |       2205        |     sa      |      -      |             [keys](/otp/keys.txt)             |
+|               ed25519                |       2206        |     sa      |      -      |        [ed25519 key](/keys/id_ed25519)        |
+|            ecdsa-nistp256            |       2207        |     sa      |      -      |   [ecDSA 256 key](/keys/id_ecdsa_nistp256)    |
+|            ecdsa-nistp384            |       2218        |     sa      |      -      |   [ecDSA 384 key](/keys/id_ecdsa_nistp384)    |
+|            ecdsa-nistp521            |       2219        |     sa      |      -      |   [ecDSA 521 key](/keys/id_ecdsa_nistp521)    |
+|            hmac-sha2-256             |       2208        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|            hmac-sha2-512             |       2209        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|   chacha20-poly1305_at_openssh.com   |       2210        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              aes128-ctr              |       2211        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              aes192-ctr              |       2212        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              aes256-ctr              |       2213        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|          curve25519-sha256           |       2214        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+| diffie-hellman-group-exchange-sha256 |       2215        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|                telnet                |       2216        |     sa      |    pass     |                       -                       |
+|                chain1                |       2217        |   chain1    |      1      |                       -                       |
+|                chain2                |         -         |   chain2    |      -      |            [rsa key](/keys/id_rsa)            |
+|                chain3                |         -         |   chain3    |      -      |           [rsa1 key](/keys/id_rsa1)           |
+|               yuubikey               |       2220        |     sa      |      -      |                       -                       |
+|             yuubikey-pam             |       2221        |     sa      |      -      |                       -                       |
+|      agent-forwarding-disabled       |       2222        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|            gateway-ports             |       2223        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|                 mosh                 | 2224, 60001 (udp) |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|            multiple-auths            |       2225        |     sa      |    pass     |            [rsa key](/keys/id_rsa)            |
+|      keyboard-interactive-pass       |       2226        |     sa      |    pass     |                       -                       |
+|            sftp-disabled             |       2227        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|             pf-disabled              |       2228        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|             pf-case-jump             |       2230        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|             client-cert              |       2231        |     sa      |      -      | [user certificate key](/client-cert/user-key) |
+|            mosh-unstable             | 2232, 60003 (udp) |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
 
 ### Table of proxy hosts
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - '2202:22'
 
   http-proxy:
-    mem_limit: 256m
+    mem_limit: 512m
     build: http-proxy
     ports:
       - '8888:3128'
@@ -392,6 +392,22 @@ services:
       CONFIG: sshd_config
     ports:
       - '2231:22'
+
+  mosh-unstable:
+    mem_limit: 64m
+    build:
+      context: .
+      dockerfile: mosh/Dockerfile
+    cap_add:
+      - NET_ADMIN
+    environment:
+      UNSTABLE_NETWORK: "true"
+      ADMIN: sa
+      CONFIG: sshd_config
+      PUB_KEY_NAME: id_rsa.pub
+    ports:
+      - '2232:22'
+      - '60003:60003/udp'
 
 networks:
   pf-case-keystorage:

--- a/mosh/Dockerfile
+++ b/mosh/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
     tmux byobu emacs vim mc htop curl
 
-RUN apt-get install -y mosh locales
+RUN apt-get install -y mosh locales iproute2
 
 RUN locale-gen en_US.UTF-8
 

--- a/mosh/entrypoint.sh
+++ b/mosh/entrypoint.sh
@@ -32,5 +32,9 @@ add_credential $ADMIN
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
 
+if [ -n "$UNSTABLE_NETWORK" ]; then
+    tc qdisc add dev eth0 root netem delay 500ms 500ms drop 10%
+fi
+
 echo 'Start sshd'
 /usr/sbin/sshd -D


### PR DESCRIPTION
## Description of the change

This change adds a mosh server that has an unstable network to test predictions in such conditions.

## Type of change

- [x] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.