### PR TITLE
Add tools for testing and mosh pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 ADD sshd_configs_raw /tmp/

--- a/README.md
+++ b/README.md
@@ -31,41 +31,42 @@ When you want to add new server configuration follow step below:
 
 ## Table of available hosts
 
-|               Service                |       Port        |    User     |  Password   |                      Key                      |
-|:------------------------------------:|:-----------------:|:-----------:|:-----------:|:---------------------------------------------:|
-|                 pass                 |       2201        |     sa      |    pass     |                       -                       |
-|                 key                  |       2202        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|               authykey               |       2203        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              authypass               |       2204        | Authy users | authy_token |                       -                       |
-|                 otp                  |       2205        |     sa      |      -      |             [keys](/otp/keys.txt)             |
-|               ed25519                |       2206        |     sa      |      -      |        [ed25519 key](/keys/id_ed25519)        |
-|            ecdsa-nistp256            |       2207        |     sa      |      -      |   [ecDSA 256 key](/keys/id_ecdsa_nistp256)    |
-|            ecdsa-nistp384            |       2218        |     sa      |      -      |   [ecDSA 384 key](/keys/id_ecdsa_nistp384)    |
-|            ecdsa-nistp521            |       2219        |     sa      |      -      |   [ecDSA 521 key](/keys/id_ecdsa_nistp521)    |
-|            hmac-sha2-256             |       2208        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|            hmac-sha2-512             |       2209        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|   chacha20-poly1305_at_openssh.com   |       2210        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              aes128-ctr              |       2211        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              aes192-ctr              |       2212        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|              aes256-ctr              |       2213        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|          curve25519-sha256           |       2214        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-| diffie-hellman-group-exchange-sha256 |       2215        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|                telnet                |       2216        |     sa      |    pass     |                       -                       |
-|                chain1                |       2217        |   chain1    |      1      |                       -                       |
-|                chain2                |         -         |   chain2    |      -      |            [rsa key](/keys/id_rsa)            |
-|                chain3                |         -         |   chain3    |      -      |           [rsa1 key](/keys/id_rsa1)           |
-|               yuubikey               |       2220        |     sa      |      -      |                       -                       |
-|             yuubikey-pam             |       2221        |     sa      |      -      |                       -                       |
-|      agent-forwarding-disabled       |       2222        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|            gateway-ports             |       2223        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|                 mosh                 | 2224, 60001 (udp) |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|            multiple-auths            |       2225        |     sa      |    pass     |            [rsa key](/keys/id_rsa)            |
-|      keyboard-interactive-pass       |       2226        |     sa      |    pass     |                       -                       |
-|            sftp-disabled             |       2227        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|             pf-disabled              |       2228        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|             pf-case-jump             |       2230        |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
-|             client-cert              |       2231        |     sa      |      -      | [user certificate key](/client-cert/user-key) |
-|            mosh-unstable             | 2232, 60003 (udp) |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|               Service                |          Port           |    User     |  Password   |                      Key                      |
+|:------------------------------------:|:-----------------------:|:-----------:|:-----------:|:---------------------------------------------:|
+|                 pass                 |          2201           |     sa      |    pass     |                       -                       |
+|                 key                  |          2202           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|               authykey               |          2203           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              authypass               |          2204           | Authy users | authy_token |                       -                       |
+|                 otp                  |          2205           |     sa      |      -      |             [keys](/otp/keys.txt)             |
+|               ed25519                |          2206           |     sa      |      -      |        [ed25519 key](/keys/id_ed25519)        |
+|            ecdsa-nistp256            |          2207           |     sa      |      -      |   [ecDSA 256 key](/keys/id_ecdsa_nistp256)    |
+|            ecdsa-nistp384            |          2218           |     sa      |      -      |   [ecDSA 384 key](/keys/id_ecdsa_nistp384)    |
+|            ecdsa-nistp521            |          2219           |     sa      |      -      |   [ecDSA 521 key](/keys/id_ecdsa_nistp521)    |
+|            hmac-sha2-256             |          2208           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|            hmac-sha2-512             |          2209           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|   chacha20-poly1305_at_openssh.com   |          2210           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              aes128-ctr              |          2211           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              aes192-ctr              |          2212           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              aes256-ctr              |          2213           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|          curve25519-sha256           |          2214           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+| diffie-hellman-group-exchange-sha256 |          2215           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|                telnet                |          2216           |     sa      |    pass     |                       -                       |
+|                chain1                |          2217           |   chain1    |      1      |                       -                       |
+|                chain2                |            -            |   chain2    |      -      |            [rsa key](/keys/id_rsa)            |
+|                chain3                |            -            |   chain3    |      -      |           [rsa1 key](/keys/id_rsa1)           |
+|               yuubikey               |          2220           |     sa      |      -      |                       -                       |
+|             yuubikey-pam             |          2221           |     sa      |      -      |                       -                       |
+|      agent-forwarding-disabled       |          2222           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|            gateway-ports             |          2223           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|                 mosh                 | 2224, 60001-60010 (udp) |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|            multiple-auths            |          2225           |     sa      |    pass     |            [rsa key](/keys/id_rsa)            |
+|      keyboard-interactive-pass       |          2226           |     sa      |    pass     |                       -                       |
+|            sftp-disabled             |          2227           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|             pf-disabled              |          2228           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|             pf-case-jump             |          2230           |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|             client-cert              |          2231           |     sa      |      -      | [user certificate key](/client-cert/user-key) |
+|            mosh-unstable             | 2232, 60021-60030 (udp) |     sa      |      -      |            [rsa key](/keys/id_rsa)            |
+|              mosh-pass               | 2233, 60011-60020 (udp) |     sa      |    pass     |                       -                       |
 
 ### Table of proxy hosts
 

--- a/agent-forwarding-disabled/Dockerfile
+++ b/agent-forwarding-disabled/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD agent-forwarding-disabled/entrypoint.sh /usr/bin/entrypoint.sh
 ADD agent-forwarding-disabled/sshd_config /etc/ssh/sshd_config

--- a/authykey/Dockerfile
+++ b/authykey/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 RUN curl -O 'https://raw.githubusercontent.com/authy/authy-ssh/master/authy-ssh'
 

--- a/authypass/Dockerfile
+++ b/authypass/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 RUN curl -O 'https://raw.githubusercontent.com/authy/authy-ssh/master/authy-ssh'
 

--- a/client-cert/Dockerfile
+++ b/client-cert/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 ADD sshd_config /etc/ssh/sshd_config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,7 +290,7 @@ services:
     ports:
       - '2223:22'
 
-  mosh:
+  mosh-key:
     mem_limit: 64m
     build:
       context: .
@@ -301,7 +301,7 @@ services:
       PUB_KEY_NAME: id_rsa.pub
     ports:
       - '2224:22'
-      - '60001:60001/udp'
+      - '60001-60010:60001-60010/udp'
 
   multiple-auths:
     mem_limit: 64m
@@ -407,7 +407,20 @@ services:
       PUB_KEY_NAME: id_rsa.pub
     ports:
       - '2232:22'
-      - '60003:60003/udp'
+      - '60021-60030:60021-60030/udp'
+
+  mosh-pass:
+    mem_limit: 64m
+    build:
+      context: .
+      dockerfile: mosh/Dockerfile
+    environment:
+      ADMIN: sa
+      ADMIN_PASS: pass
+      CONFIG: sshd_config
+    ports:
+      - '2233:22'
+      - '60011-60020:60011-60020/udp'
 
 networks:
   pf-case-keystorage:

--- a/gateway-ports/Dockerfile
+++ b/gateway-ports/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 RUN apt-get install -y python
 

--- a/http-proxy/Dockerfile
+++ b/http-proxy/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y squid
 COPY squid.conf /etc/squid/squid.conf
 EXPOSE 3128

--- a/keyboard-interactive-pass/Dockerfile
+++ b/keyboard-interactive-pass/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD keyboard-interactive-pass/entrypoint.sh /usr/bin/entrypoint.sh
 ADD keyboard-interactive-pass/sshd_config /etc/ssh/sshd_config

--- a/mosh/Dockerfile
+++ b/mosh/Dockerfile
@@ -1,12 +1,15 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
-RUN apt-get install -y mosh locales iproute2
-
-RUN locale-gen en_US.UTF-8
+RUN apt-get install -y mosh iproute2
 
 ADD mosh/entrypoint.sh /usr/bin/entrypoint.sh
 ADD mosh/sshd_config /etc/ssh/sshd_config

--- a/mosh/entrypoint.sh
+++ b/mosh/entrypoint.sh
@@ -5,8 +5,7 @@ create_user() {
     useradd -d /home/$1 -G remote -m $1
 }
 
-add_credential() {
-    passwd -d $1
+add_key() {
     mkdir -p /home/$1/.ssh/
     cat /tmp/$PUB_KEY_NAME > /home/$1/.ssh/authorized_keys
     chmod 700 /home/$1/.ssh
@@ -24,10 +23,20 @@ add_credential() {
     fi
 }
 
+add_pass() {
+    mkdir -p /home/$1/.ssh/
+    if [ -z "$ADMIN_PASS" ]; then
+        passwd -d $1
+    else
+        echo "$ADMIN:$ADMIN_PASS" | chpasswd
+    fi
+}
+
 mkdir /var/run/sshd
 
 create_user $ADMIN
-add_credential $ADMIN
+add_key $ADMIN
+add_pass $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log

--- a/multiple-auths/Dockerfile
+++ b/multiple-auths/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD multiple-auths/entrypoint.sh /usr/bin/entrypoint.sh
 ADD multiple-auths/sshd_config /etc/ssh/sshd_config

--- a/otp/Dockerfile
+++ b/otp/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 RUN apt-get install -y otpw-bin libpam-otpw
 

--- a/pass/Dockerfile
+++ b/pass/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD pass/entrypoint.sh /usr/bin/entrypoint.sh
 ADD pass/sshd_config /etc/ssh/sshd_config

--- a/sftp-disabled/Dockerfile
+++ b/sftp-disabled/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 ADD keys /tmp/

--- a/telnet/Dockerfile
+++ b/telnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos6
+FROM centos:centos7
 
 RUN yum install telnet telnet-server -y && \
   yum install -y tmux byobu emacs vim mc htop curl

--- a/yubikey-pam/Dockerfile
+++ b/yubikey-pam/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 RUN apt-get install -y libpam-yubico
 

--- a/yubikey/Dockerfile
+++ b/yubikey/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl
+    tmux byobu emacs vim mc htop curl \
+    bb cmatrix libaa-bin
 
 RUN \
     apt-get install -y gnupg2 pcscd scdaemon curl \


### PR DESCRIPTION
## Description of the change

This change simplifies using host farm for testing Termius by adding terminal tools to
test terminal rendering and testing mosh connections with password.

## Type of change

- [x] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.