### PR TITLE
Adding support of SFTP to 2201

### DIFF
--- a/pass/sshd_config
+++ b/pass/sshd_config
@@ -4,3 +4,4 @@ PasswordAuthentication yes
 AllowGroups remote
 LogLevel DEBUG3
 PrintLastLog no
+Subsystem       sftp    /usr/lib/openssh/sftp-server


### PR DESCRIPTION
We need to be able to test SFTP connection with login/password, that's why we decided to add support of SFTP to 2201 (pass) service.

## Description of the change

Description here

## Type of change

- [ ] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.
