### PR TITLE
Regenerate the host key on the container start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,9 @@ chmod 666 /var/log/auth.log
 /usr/sbin/syslog-ng -F &
 /bin/sanitize-auth-log.sh &
 
+rm /etc/ssh/ssh_host_*_key
+ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
+
 echo 'Start daemon'
 echo "$@"
 exec "$@"

--- a/pass/entrypoint.sh
+++ b/pass/entrypoint.sh
@@ -32,5 +32,8 @@ add_credential $ADMIN $ADMIN_PASS
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
 
+rm /etc/ssh/ssh_host_*_key
+ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
+
 echo 'Start daemon'
 exec /usr/sbin/sshd -D


### PR DESCRIPTION
## Description of the change

This change makes sure all containers have their own SSH host keys.

## Type of change

- [x] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [x] The code does not have any obvious logic errors.
- [x] All cases specified in the requirements are fully implemented.
- [x] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [x] The new code conforms to existing style guidelines.