### PR TITLE
Install vttest to host farms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/anomaly-exec/Dockerfile
+++ b/anomaly-exec/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/authykey/Dockerfile
+++ b/authykey/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/authypass/Dockerfile
+++ b/authypass/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/client-cert/Dockerfile
+++ b/client-cert/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/dropbear/Dockerfile
+++ b/dropbear/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server dropbear gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/gateway-ports/Dockerfile
+++ b/gateway-ports/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/hostkey-order/Dockerfile
+++ b/hostkey-order/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/keyboard-interactive-custom/Dockerfile
+++ b/keyboard-interactive-custom/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     libpam-python
 

--- a/keyboard-interactive-edgecases/Dockerfile
+++ b/keyboard-interactive-edgecases/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/keyboard-interactive-pass/Dockerfile
+++ b/keyboard-interactive-pass/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/mosh/Dockerfile
+++ b/mosh/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/multiple-auths/Dockerfile
+++ b/multiple-auths/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/otp/Dockerfile
+++ b/otp/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/pass/Dockerfile
+++ b/pass/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/raspbian/Dockerfile
+++ b/raspbian/Dockerfile
@@ -5,7 +5,7 @@ FROM balenalib/rpi-raspbian:bullseye-20220125
 # ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/sftp-disabled/Dockerfile
+++ b/sftp-disabled/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 

--- a/yubikey-pam/Dockerfile
+++ b/yubikey-pam/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get upgrade -y && \
   apt-get install -y openssh-server gettext-base syslog-ng \
-    tmux byobu emacs vim mc htop curl nano \
+    vttest tmux byobu emacs vim mc htop curl nano \
     bb cmatrix libaa-bin \
     zsh git
 


### PR DESCRIPTION
## Description of the change
This changes installs `vttest` to the list of pre-installed terminal tools.

## Type of change

- [x] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.
