### PR TITLE
Add chain with max auth tries for key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1154,6 +1154,7 @@ services:
     restart: "unless-stopped"
     links:
       - chain2
+      - chain2-auth-tries-1
       - http-proxy-chain2
 
   chain2:
@@ -1164,6 +1165,20 @@ services:
       CONFIG: sshd_config
       PUB_KEY_NAME: id_rsa.pub
       PRIVATE_KEY_NAME: id_rsa1
+    restart: "unless-stopped"
+    links:
+      - chain3
+      - http-proxy-chain3
+
+  chain2-auth-tries-1:
+    mem_limit: 64m
+    build: .
+    environment:
+      ADMIN: chain2
+      CONFIG: sshd_config
+      PUB_KEY_NAME: id_rsa.pub
+      PRIVATE_KEY_NAME: id_rsa1
+      MAX_AUTH_TRIES: MaxAuthTries 1
     restart: "unless-stopped"
     links:
       - chain3

--- a/sshd_configs_raw/sshd_config
+++ b/sshd_configs_raw/sshd_config
@@ -8,3 +8,4 @@ SyslogFacility AUTHPRIV
 Subsystem sftp /usr/lib/openssh/sftp-server -l DEBUG3
 PrintLastLog no
 AcceptEnv LANG LC_*
+${MAX_AUTH_TRIES}


### PR DESCRIPTION
## Description of the change

Add a new host into chain with `MaxAuthTries` configured based on `chain2`.


## Type of change

- [x] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.
